### PR TITLE
Added TTbar reconstruction with smearing

### DIFF
--- a/histFactory/launchHistFactory.py
+++ b/histFactory/launchHistFactory.py
@@ -20,11 +20,12 @@ SCRAM_ARCH = os.environ['SCRAM_ARCH']
 sys.path.append(os.path.join(CMSSW_BASE,'bin', SCRAM_ARCH))
 
 # Prod 16/03/07
-#IDs = range(1462, 1483)
-#IDs.remove(1479)
-IDs = []
+IDs = range(1462, 1483)
+IDs.remove(1479)
+IDs.remove(1471)
+IDs.append(1506)
 
-parser = argparse.ArgumentParser(description='Facility to submit histFactory jobs on condor.', usage='Usage in TTTools/histFactory: python launchHistFactory.py -o condorOutDir -t -p pathToPlotterExe [-s]')
+parser = argparse.ArgumentParser(description='Facility to submit histFactory jobs on condor.', usage='Usage in TTTools/histFactory: python launchHistFactory.py -o condorOutDir -f -p pathToPlotterExe [-s]')
 parser.add_argument('-o', '--output', dest='output', default=str(datetime.date.today()), help='Name of output directory.')
 parser.add_argument('-s', '--submit', help='Choice to actually submit the jobs or not.', action="store_true")
 parser.add_argument('-f', '--filter', dest='filter', default=False, help='Apply filter on DY ht and TT lepton flavour.', action="store_true")
@@ -74,16 +75,16 @@ if args.filter :
                     jsonSample[ttflname]["sample_cut"] = "(tt_gen_ttbar_decay_type >= 4 && tt_gen_ttbar_decay_type <= 6 ) || tt_gen_ttbar_decay_type >= 8"
                     jsonSample[ttflname]["output_name"] += "_diLep"
 
-                    #ttslname = sampleName + "_semiLep"
-                    #jsonSample[ttslname] = copy.deepcopy(jsonSample[sampleName])
-                    #jsonSample[ttslname]["sample_cut"] = "tt_gen_ttbar_decay_type == 2 || tt_gen_ttbar_decay_type == 3 || tt_gen_ttbar_decay_type == 7"
-                    #jsonSample[ttslname]["output_name"] += "_semiLep"
+                    ttslname = sampleName + "_semiLep"
+                    jsonSample[ttslname] = copy.deepcopy(jsonSample[sampleName])
+                    jsonSample[ttslname]["sample_cut"] = "tt_gen_ttbar_decay_type == 2 || tt_gen_ttbar_decay_type == 3 || tt_gen_ttbar_decay_type == 7"
+                    jsonSample[ttslname]["output_name"] += "_semiLep"
 
-                    #ttfhname = sampleName + "_hadr"
-                    #jsonSample[ttfhname] = copy.deepcopy(jsonSample[sampleName])
-                    #jsonSample[ttfhname]["sample_cut"] = "tt_gen_ttbar_decay_type <= 1"
-                    #jsonSample[ttfhname]["output_name"] += "_hadr"
-                    #jsonSample.pop(sampleName)
+                    ttfhname = sampleName + "_hadr"
+                    jsonSample[ttfhname] = copy.deepcopy(jsonSample[sampleName])
+                    jsonSample[ttfhname]["sample_cut"] = "tt_gen_ttbar_decay_type <= 1"
+                    jsonSample[ttfhname]["output_name"] += "_hadr"
+                    jsonSample.pop(sampleName)
 
         with open(jsonSampleFilePath, 'w+') as jsonSampleFile :
             json.dump(jsonSample, jsonSampleFile)

--- a/histFactory/plots/TTbarReconstruction/SmearingFunction.h
+++ b/histFactory/plots/TTbarReconstruction/SmearingFunction.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <string>
+
+#include <Math/Vector4D.h>
+#include <TH2.h>
+#include <TH1.h>
+#include <TFile.h>
+
+class SmearingFunction {
+  public:
+    
+    SmearingFunction() {}
+    virtual ~SmearingFunction() {}
+
+    virtual double Evaluate(const myLorentzVector& input, myLorentzVector& output, const double psPoint) const { return 0;}
+    virtual double Evaluate(double& output, const double psPoint) const { return 0; }
+
+};
+
+
+class DiracDelta: public SmearingFunction {
+
+  public:
+
+    DiracDelta() {}
+    DiracDelta(double value): value(value) {}
+    virtual ~DiracDelta() {}
+
+    virtual double Evaluate(const myLorentzVector& input, myLorentzVector& output, const double psPoint) const {
+      output = input;
+      return 1;
+    }
+    
+    virtual double Evaluate(double& output, const double psPoint) const {
+      output = value;
+      return 1;
+    }
+
+  private:
+
+    double value;
+};
+
+
+class SimpleGaussianOnEnergy: public SmearingFunction {
+
+  public:
+
+    // stdDev is s.t. the standard deviation of the gaussian = Egen*stdDev
+    // range is s.t. Egen is generated over an interval of length 2*Ereco*stdDev*range
+    SimpleGaussianOnEnergy(const double mean, const double stdDev, const double range):
+      mean(mean), stdDev(stdDev), range(range)
+      {}
+    virtual ~SimpleGaussianOnEnergy() {}
+
+    virtual double Evaluate(const myLorentzVector& input, myLorentzVector& output, const double psPoint) const {
+      double Egen = input.E() - range*stdDev*input.E() + 2*range*stdDev*input.E()*psPoint;
+      const double pTgen = sqrt( pow(Egen, 2) - pow(input.M(), 2) ) / cosh(input.Eta());
+      output.SetCoordinates(pTgen, input.Eta(), input.Phi(), Egen);
+      
+      return exp( -pow(mean - (input.E()-Egen), 2)/(2*pow(stdDev*Egen, 2)) ) / sqrt(2*M_PI) / (stdDev*Egen);
+    }
+    
+  private:
+    
+    double mean, stdDev, range;
+
+};
+
+
+class BreitWigner: public SmearingFunction {
+
+  public:
+
+    BreitWigner(const double mass, const double width, const double range):
+      mass(mass), width(width), range(range)
+    {
+      if(width*range >= mass)
+        std::cout << "Warning: Breit-Wigner is only physical near the resonance." << std::endl;
+    }
+    
+    virtual double Evaluate(double &output, const double psPoint) const {
+      const double s = -range*width + 2*range*width*psPoint; 
+
+      const double gamma = sqrt( pow(mass, 2) * (pow(mass, 2) + pow(width, 2)));
+      const double k = 2*sqrt(2)*mass*width*gamma/(M_PI*sqrt(pow(mass, 2) + gamma));
+
+      return k/(pow(s - pow(mass, 2), 2) + pow(mass*width, 2));
+    }
+
+  private:
+
+    double mass, width, range;
+};
+
+
+class Binned1DTransferFunction: public SmearingFunction {
+  public:
+
+    Binned1DTransferFunction(const std::string histName, TFile* file, double offset=0): _offset(offset) {
+      _TF = dynamic_cast<TH1D*>( file->Get(histName.c_str()) );
+      if(!_TF){
+        std::cerr << "Error when defining 1D binned TF: unable to retrieve " << histName << " from file " << file->GetPath() << ".\n";
+        exit(1);
+      }
+
+      std::cout << "Creating 1D TF from histogram " << histName << ".\n";
+
+      _min = _TF->GetXaxis()->GetXmin();
+      _max = _TF->GetXaxis()->GetXmax();
+      _range = _max - _min; 
+ 
+      std::cout << "Delta range is " << _range << ", min. and max. values are " << _min << ", " << _max << std::endl << std::endl;
+    }
+ 
+    virtual ~Binned1DTransferFunction(){
+      delete _TF; _TF = nullptr;
+    }
+    
+    virtual double Evaluate(double &output, const double psPoint) const {
+      output = _min + _range*psPoint;
+      const int bin = _TF->FindFixBin(output);
+      output += _offset;
+      return _TF->GetBinContent(bin);
+    }
+
+  private:
+
+    double _min, _max, _range, _offset;
+    const TH1D* _TF;
+};
+
+
+class Binned2DTransferFunction: public SmearingFunction {
+  
+  public:
+
+    Binned2DTransferFunction(const std::string histName, TFile* file){
+      _TF = dynamic_cast<TH2D*>( file->Get(histName.c_str()) );
+      if(!_TF){
+        std::cerr << "Error when defining 2D binned TF: unable to retrieve " << histName << " from file " << file->GetPath() << ".\n";
+        exit(1);
+      }
+
+      std::cout << "Creating 2D TF from histogram " << histName << ".\n";
+
+      _deltaMin = _TF->GetYaxis()->GetXmin();
+      _deltaMax = _TF->GetYaxis()->GetXmax();
+      _deltaRange = _deltaMax - _deltaMin; 
+      _EgenMax = _TF->GetXaxis()->GetXmax();
+      _EgenMin = _TF->GetXaxis()->GetXmin();
+ 
+      std::cout << "Delta range is " << _deltaRange << ", min. and max. values are " << _EgenMin << ", " <<_EgenMax << std::endl << std::endl;
+    }
+ 
+    virtual ~Binned2DTransferFunction(){
+      delete _TF; _TF = nullptr;
+    }
+    
+    virtual double Evaluate(const myLorentzVector& input, myLorentzVector& output, const double psPoint) const {
+      const double Erec = input.E();
+      const double Erange = GetDeltaRange(Erec);
+      const double Egen = Erec - GetDeltaMax(Erec) + Erange * psPoint;
+      const double pTgen = sqrt( pow(Egen, 2) - pow(input.M(), 2) ) / cosh(input.Eta());
+      output.SetCoordinates(pTgen, input.Eta(), input.Phi(), Egen);
+      
+      const double delta = Erec - Egen;
+      if(Egen < _EgenMin || Egen > _EgenMax || delta > _deltaMax || delta < _deltaMin)
+        return 0.;
+
+      // Use ROOT's global bin number "feature" for 2-dimensional histograms
+      const int bin = _TF->FindFixBin(Egen, delta);
+      return _TF->GetBinContent(bin);
+    }
+    
+    double GetDeltaRange(const double &Erec) const {
+      return GetDeltaMax(Erec) - GetDeltaMin(Erec);
+    }
+
+    double GetDeltaMin(const double &Erec) const {
+      return std::max(_deltaMin, Erec - _EgenMax);
+    }
+
+    double GetDeltaMax(const double &Erec) const {
+      return std::min(_deltaMax, Erec - _EgenMin);
+    }
+    
+  private:
+
+    double _deltaMin, _deltaMax, _deltaRange;
+    double _EgenMax, _EgenMin;
+    const TH2D* _TF;
+};

--- a/histFactory/plots/TTbarReconstruction/TTbarReconstructor.h
+++ b/histFactory/plots/TTbarReconstruction/TTbarReconstructor.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <cp3_llbb/TTAnalysis/interface/Types.h>
+#include <cp3_llbb/TTAnalysis/interface/NeutrinosSolver.h>
+
+#include <iostream>
+#include <algorithm>
+#include <utility>
+#include <random>
+
+#include <Math/Vector4D.h>
+
+//#define RECO_DEBUG
+
+#define PRINT_VECTOR(vec) std::cout << "Vector " << #vec << ": " << vec << std::endl;
+
+#define PRINT_VECTORS(vec) \
+  PRINT_VECTOR(vec) \
+  PRINT_VECTOR(gen_##vec)
+
+// Needed because it is defined in TTAnalyzer.cc, which is not compiled here
+float TTAnalysis::DeltaEta(const myLorentzVector& v1, const myLorentzVector& v2) {
+    return std::abs(v1.Eta() - v2.Eta());
+}
+
+class TTbarReconstructor {
+  public:
+    
+    TTbarReconstructor(SmearingFunction& muonSmearing, SmearingFunction& electronSmearing, SmearingFunction& bJetSmearing, SmearingFunction& WSmearing, SmearingFunction& TopSmearing, uint32_t nTries):
+      muonSmearing(muonSmearing),
+      electronSmearing(electronSmearing),
+      bJetSmearing(bJetSmearing),
+      WSmearing(WSmearing),
+      TopSmearing(TopSmearing),
+      nTries(nTries),
+      myPSgen(0,1)
+    {}
+
+    TTAnalysis::TTBar getSolution(
+        const myLorentzVector& lepton1_p4,
+        const myLorentzVector& lepton2_p4,
+        const myLorentzVector& bjet1_p4,
+        const myLorentzVector& bjet2_p4,
+        const myLorentzVector& met_p4,
+        const bool isElEl, const bool isElMu, const bool isMuEl, const bool isMuMu){
+
+#ifdef RECO_DEBUG
+        std::cout << "\nStarting event\n";
+#endif
+      
+      if( (!isElEl && !isElMu && !isMuEl && !isMuMu) || (isElEl+isMuEl+isElMu+isMuMu) > 1){
+        std::cout << "Error: channel is wrongly specified" << std::endl;
+        return TTAnalysis::TTBar(0, myLorentzVector(), myLorentzVector());
+      }
+
+      myLorentzVector top_p4, antiTop_p4;
+      double totWeight(0);
+
+      for(uint32_t i = 0; i < nTries; ++i){
+
+        double thisWeight(1);
+
+        // Smear all quantities according to pre-defined distributions        
+        double new_w_mass;
+        thisWeight *= WSmearing.Evaluate(new_w_mass, myPSgen(myGenerator));
+        double new_t_mass;
+        thisWeight *= TopSmearing.Evaluate(new_t_mass, myPSgen(myGenerator));
+
+#ifdef RECO_DEBUG
+        std::cout << "W/top masses: " << new_w_mass << "/" << new_t_mass << std::endl;
+#endif
+
+        myLorentzVector gen_lepton1_p4, gen_lepton2_p4, gen_bjet1_p4, gen_bjet2_p4;
+        
+        if(isElEl || isElMu)
+          thisWeight *= electronSmearing.Evaluate(lepton1_p4, gen_lepton1_p4, myPSgen(myGenerator));
+        if(isMuEl || isMuMu)
+          thisWeight *= muonSmearing.Evaluate(lepton1_p4, gen_lepton1_p4, myPSgen(myGenerator));
+        if(isElEl || isMuEl)
+          thisWeight *= electronSmearing.Evaluate(lepton2_p4, gen_lepton2_p4, myPSgen(myGenerator));
+        if(isElMu || isMuMu)
+          thisWeight *= muonSmearing.Evaluate(lepton2_p4, gen_lepton2_p4, myPSgen(myGenerator));
+          
+        thisWeight *= bJetSmearing.Evaluate(bjet1_p4, gen_bjet1_p4, myPSgen(myGenerator));
+        thisWeight *= bJetSmearing.Evaluate(bjet2_p4, gen_bjet2_p4, myPSgen(myGenerator));
+
+#ifdef RECO_DEBUG
+        PRINT_VECTORS(lepton1_p4)
+        PRINT_VECTORS(lepton2_p4)
+        PRINT_VECTORS(bjet1_p4)
+        PRINT_VECTORS(bjet2_p4)
+        PRINT_VECTOR(met_p4)
+        std::cout << "Weight: " << thisWeight << std::endl;
+#endif
+        
+        // Get neutrino solutions, reconstruct ttbar system
+        NeutrinosSolver mySolver(new_t_mass, new_w_mass);
+        std::vector<TTAnalysis::TTBar> this_ttbar;
+
+        auto neutrinos = mySolver.getNeutrinos(
+            NeutrinosSolver::LorentzVector(gen_lepton1_p4),
+            NeutrinosSolver::LorentzVector(gen_lepton2_p4),
+            NeutrinosSolver::LorentzVector(gen_bjet1_p4),
+            NeutrinosSolver::LorentzVector(gen_bjet2_p4),
+            NeutrinosSolver::LorentzVector(met_p4));
+
+#ifdef RECO_DEBUG
+        std::cout << "First permutation: " << neutrinos.size() << " solutions.\n";
+#endif
+        
+        for(const auto& thisPair: neutrinos)
+          this_ttbar.push_back( TTAnalysis::TTBar(1, myLorentzVector(gen_lepton1_p4+gen_bjet1_p4+myLorentzVector(thisPair.first)), myLorentzVector(gen_lepton2_p4+gen_bjet2_p4+myLorentzVector(thisPair.second))) );
+
+        // Do it again, swapping b and bbar
+        std::swap(gen_bjet1_p4, gen_bjet2_p4);
+        neutrinos = mySolver.getNeutrinos(
+            NeutrinosSolver::LorentzVector(gen_lepton1_p4),
+            NeutrinosSolver::LorentzVector(gen_lepton2_p4),
+            NeutrinosSolver::LorentzVector(gen_bjet1_p4),
+            NeutrinosSolver::LorentzVector(gen_bjet2_p4),
+          NeutrinosSolver::LorentzVector(met_p4));
+
+#ifdef RECO_DEBUG
+        std::cout << "Second permutation: " << neutrinos.size() << " solutions.\n";
+#endif
+        
+        for(const auto& thisPair: neutrinos)
+          this_ttbar.push_back( TTAnalysis::TTBar(1, myLorentzVector(gen_lepton1_p4+gen_bjet1_p4+myLorentzVector(thisPair.first)), myLorentzVector(gen_lepton2_p4+gen_bjet2_p4+myLorentzVector(thisPair.second))) );
+
+        // Sort the solutions according to invariant TTbar mass, to keep only the lowest mass
+        std::sort(this_ttbar.begin(), this_ttbar.end(), [](const TTAnalysis::TTBar& a, const TTAnalysis::TTBar& b) { return a.p4.M() < b.p4.M(); } );
+
+        if( !this_ttbar.size() )
+          continue;
+        
+        top_p4 += thisWeight * this_ttbar.at(0).top1_p4; 
+        antiTop_p4 += thisWeight * this_ttbar.at(0).top2_p4; 
+        totWeight += thisWeight;
+      }
+
+      // No solutions found! Return dummy solution with index set to 0
+      if( totWeight == 0 )
+        return TTAnalysis::TTBar(0, myLorentzVector(), myLorentzVector());
+
+      top_p4 /= totWeight;
+      antiTop_p4 /= totWeight;
+      
+      // Success: return solution with index set to 1
+      return TTAnalysis::TTBar(1, top_p4, antiTop_p4);
+    }
+    
+  private:
+
+    SmearingFunction& muonSmearing;
+    SmearingFunction& electronSmearing;
+    SmearingFunction& bJetSmearing;
+    SmearingFunction& WSmearing;
+    SmearingFunction& TopSmearing;
+
+    uint32_t nTries;
+
+    std::uniform_real_distribution<double> myPSgen;
+    std::mt19937_64 myGenerator;
+};

--- a/histFactory/plots/basePlots.py
+++ b/histFactory/plots/basePlots.py
@@ -848,6 +848,8 @@ llbb = [
         #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
         #    'binning': (50, 0, 3.14159)
         #},
+        
+        ## TT reconstruction without smearing
         { 
             'name': 'llbbMet_TT_M_CAT_#CAT_TITLE#',
             'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M()',
@@ -865,31 +867,6 @@ llbb = [
             'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.Eta()',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0'),
             'binning': (25, -5, 5)
-        },
-        ## MTT Resolution
-        { 
-            'name': 'llbbMet_TT_M_minus_Mgen_beforeFSR_CAT_#CAT_TITLE#',
-            'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
-            'binning': (100, -1000, 1000)
-        },
-        { 
-            'name': 'llbbMet_TT_M_resolution_beforeFSR_CAT_#CAT_TITLE#',
-            'variable': '(tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()) / tt_gen_ttbar_beforeFSR_p4.M() ' ,
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
-            'binning': (200, -10, 10)
-        },
-        { 
-            'name': 'llbbMet_TT_M_minus_Mgen_CAT_#CAT_TITLE#',
-            'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_p4.M()',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
-            'binning': (100, -1000, 1000)
-        },
-        { 
-            'name': 'llbbMet_TT_M_resolution_CAT_#CAT_TITLE#',
-            'variable': '(tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_p4.M()) / tt_gen_ttbar_p4.M() ' ,
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
-            'binning': (200, -10, 10)
         },
         # Top 1
         { 
@@ -934,5 +911,96 @@ llbb = [
         #    'variable': 'abs( tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].DEta_tt )',
         #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0'),
         #    'binning': (50, 0, 6)
+        #},
+        ## Resolution
+        #{ 
+        #    'name': 'llbbMet_TT_M_resolution_beforeFSR_CAT_#CAT_TITLE#',
+        #    'variable': '(tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()) / tt_gen_ttbar_beforeFSR_p4.M() ' ,
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (200, -10, 10)
+        #},
+        #{ 
+        #    'name': 'llbbMet_TT_M_minus_Mgen_CAT_#CAT_TITLE#',
+        #    'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_p4.M()',
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (100, -1000, 1000)
+        #},
+        #{ 
+        #    'name': 'llbbMet_TT_M_resolution_CAT_#CAT_TITLE#',
+        #    'variable': '(tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_p4.M()) / tt_gen_ttbar_p4.M() ' ,
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (200, -10, 10)
+        #},
+        #{ 
+        #    'name': 'llbbMet_TT_M_minus_Mgen_beforeFSR_CAT_#CAT_TITLE#',
+        #    'variable': 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0][0].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()',
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (100, -1000, 1000)
+        #},
+
+        ## TT reconstruction with smearing
+        # Top
+        {
+            'name': 'llbbMet_RecoTop_Top_Pt_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].top1_p4.Pt()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 500)
+        },
+        {
+            'name': 'llbbMet_RecoTop_Top_Eta_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].top1_p4.Eta()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (25, -5, 5)
+        },
+        # AntiTop
+        {
+            'name': 'llbbMet_RecoTop_AntiTop_Pt_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].top2_p4.Pt()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 500)
+        },
+        {
+            'name': 'llbbMet_RecoTop_AntiTop_Eta_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].top2_p4.Eta()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (25, -5, 5)
+        },
+        # TT
+        {
+            'name': 'llbbMet_RecoTop_TT_M_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].p4.M()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 250, 3000)
+        },
+        {
+            'name': 'llbbMet_RecoTop_TT_Pt_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].p4.Pt()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 500)
+        },
+        {
+            'name': 'llbbMet_RecoTop_TT_Eta_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].p4.Eta()',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (25, -5, 5)
+        },
+        {
+            'name': 'llbbMet_RecoTop_TT_DR_CAT_#CAT_TITLE#',
+            'variable': 'recoTTbar[#RECOTTBAR_INDEX#].DR_tt',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 6)
+        },
+        ## Resolution
+        #{
+        #    'name': 'llbbMet_RecoTop_TT_M_Resolution_CAT_#CAT_TITLE#',
+        #    'variable': '(recoTTbar[#RECOTTBAR_INDEX#].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()) / tt_gen_ttbar_beforeFSR_p4.M()',
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (200, -10, 10)
+        #},
+        #{
+        #    'name': 'llbbMet_RecoTop_TT_M_minus_Mgen_CAT_#CAT_TITLE#',
+        #    'variable': 'recoTTbar[#RECOTTBAR_INDEX#].p4.M() - tt_gen_ttbar_beforeFSR_p4.M()',
+        #    'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_ttbar[#LEPLEP_IDISO_BBWP#][0].size() > 0', 'tt_gen_ttbar_decay_type > 0'),
+        #    'binning': (100, -1000, 1000)
         #},
     ]

--- a/histFactory/plots/plotTools.py
+++ b/histFactory/plots/plotTools.py
@@ -22,13 +22,13 @@ def joinCuts(*cuts):
 
 #### The IDs/... we want to run on ####
 
-electronID = { TT.LepID.L: "L" }
+electronID = { TT.LepID.M: "M" }
 #electronID = { TT.LepID.L: "L", TT.LepID.M: "M" }
 #electronID = { TT.LepID.L: "L", TT.LepID.M: "M", TT.LepID.T: "T" }
-muonID = { TT.LepID.L: "L" }
+muonID = { TT.LepID.T: "T" }
 
 electronIso = { TT.LepIso.L: "L" }
-muonIso = { TT.LepIso.L: "L" }
+muonIso = { TT.LepIso.T: "T" }
 
 #myBWPs = { wp.first: wp.second for wp in TT.BWP.map }
 #myBWPs = { TT.BWP.L: "L", TT.BWP.M: "M" } 

--- a/histFactory/plots/transferFunctions.py
+++ b/histFactory/plots/transferFunctions.py
@@ -102,7 +102,7 @@ matchedBTFs = [
         # DeltaR matching monitoring
         {
             'name': 'DR_b_CAT_#CAT_TITLE#',
-            'variable': 'tt_gen_b_beforeFSR_deltaR[#MIN_LEP_IDISO#][ tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ] ]'
+            'variable': 'tt_gen_b_beforeFSR_deltaR[#MIN_LEP_IDISO#][ tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ] ]',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#',
                 'tt_gen_b >= 0', 'tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] >= 0', '( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ])',
                 ),
@@ -110,7 +110,7 @@ matchedBTFs = [
         },
         {
             'name': 'DR_bbar_CAT_#CAT_TITLE#',
-            'variable': 'tt_gen_bbar_beforeFSR_deltaR[#MIN_LEP_IDISO#][ tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ] ]'
+            'variable': 'tt_gen_bbar_beforeFSR_deltaR[#MIN_LEP_IDISO#][ tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ] ]',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#',
                 'tt_gen_bbar >= 0', 'tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] >= 0', '( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ])',
                 ),
@@ -121,25 +121,25 @@ matchedBTFs = [
         {
             'name': 'Matched_b_CSVv2_CAT_#CAT_TITLE#',
             'variable': '( tt_gen_b >= 0 && tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] >= 0 && ( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ]) ) ? 1 : 0',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#')
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': '(2, 0, 2)',
         },
         {
             'name': 'Matched_bbar_CSVv2_CAT_#CAT_TITLE#',
             'variable': '( tt_gen_bbar >= 0 && tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] >= 0 && ( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ]) ) ? 1 : 0',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#')
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': '(2, 0, 2)',
         },
         {
             'name': 'Matched_b_Pt_CAT_#CAT_TITLE#',
             'variable': '( tt_gen_b >= 0 && tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] >= 0 && ( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_PtOrdered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_PtOrdered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_b_beforeFSR[#MIN_LEP_IDISO#] ]) ) ? 1 : 0',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#') # JET_CAT_CUTS uses CSVv2-ordered b-jet pairs, but it only requires that there is a b-jet pair present, which is true or false independently of how they're ordered
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'), # JET_CAT_CUTS uses CSVv2-ordered b-jet pairs, but it only requires that there is a b-jet pair present, which is true or false independently of how they're ordered
             'binning': '(2, 0, 2)',
         },
         {
             'name': 'Matched_bbar_Pt_CAT_#CAT_TITLE#',
             'variable': '( tt_gen_bbar >= 0 && tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] >= 0 && ( tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_PtOrdered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.first == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ] || tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_PtOrdered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second == tt_selJets_selID_DRCut[#MIN_LEP_IDISO#][ tt_gen_matched_bbar_beforeFSR[#MIN_LEP_IDISO#] ]) ) ? 1 : 0',
-            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#')
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': '(2, 0, 2)',
         },
     ]

--- a/plotIt/TT_config_ElEl.yml
+++ b/plotIt/TT_config_ElEl.yml
@@ -5,7 +5,7 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: "results/latest"
-  luminosity: 2245.440
+  luminosity: 2299.718
   luminosity-error: 0.027
   show-overflow: true
   error-fill-style: 3154

--- a/plotIt/TT_config_ElMu.yml
+++ b/plotIt/TT_config_ElMu.yml
@@ -5,7 +5,7 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: "results/latest"
-  luminosity: 2245.561
+  luminosity: 2299.856
   luminosity-error: 0.027
   show-overflow: true
   error-fill-style: 3154

--- a/plotIt/TT_config_MuEl.yml
+++ b/plotIt/TT_config_MuEl.yml
@@ -5,7 +5,7 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: "results/latest"
-  luminosity: 2245.561
+  luminosity: 2299.856
   luminosity-error: 0.027
   show-overflow: true
   error-fill-style: 3154

--- a/plotIt/TT_config_MuMu.yml
+++ b/plotIt/TT_config_MuMu.yml
@@ -5,7 +5,7 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: "results/latest"
-  luminosity: 2245.516
+  luminosity: 2299.809
   luminosity-error: 0.027
   show-overflow: true
   error-fill-style: 3154

--- a/plotIt/TT_files_MC.yml
+++ b/plotIt/TT_files_MC.yml
@@ -18,7 +18,7 @@
 
 ### TTbar ###
 
-'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_8c15dc1_diLep_histos.root':
+'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_fd2fe94_histos_diLep.root':
   type: mc
   group: TT_diLep
   #legend: 'TT diLep.'
@@ -26,7 +26,7 @@
   order: 2
   yields-title: '$t\overline{t}$ diLep.'
 
-'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_8c15dc1_semiLep_histos.root':
+'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_fd2fe94_histos_semiLep.root':
   type: mc
   group: TT_semiLep
   #legend: 'TT semiLep.'
@@ -34,7 +34,7 @@
   order: -2
   yields-title: '$t\overline{t}$ semiLep.'
 
-'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_8c15dc1_hadr_histos.root':
+'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v1.2.0+7415-75-g2a48fa7_TTAnalysis_fd2fe94_histos_hadr.root':
   type: mc
   group: TT_hadr
   #legend: 'TT hadr.'

--- a/plotIt/TT_plots_base.yml
+++ b/plotIt/TT_plots_base.yml
@@ -1065,6 +1065,8 @@
 #  save-extensions: ["png"]
 #  show-ratio: true
 
+## TT reconstruction without smearing
+
 'llbbMet_TT_M_CAT_base_ID??_Iso*':
   x-axis: "M_{t#bar{t}}"
   y-axis: "Events"
@@ -1147,6 +1149,80 @@
   show-ratio: true
 
 'llbbMet_T2_Eta_CAT_base_ID??_Iso*':
+  x-axis: "#eta_{top 2}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+## TT reconstruction with smearing
+
+'llbbMet_RecoTop_TT_M_CAT_base_ID??_Iso*':
+  x-axis: "M_{t#bar{t}}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_TT_Pt_CAT_base_ID??_Iso*':
+  x-axis: "P_{T, t#bar{t}}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_TT_Eta_CAT_base_ID??_Iso*':
+  x-axis: "#eta_{t#bar{t}}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_TT_DR_CAT_base_ID??_Iso*':
+  x-axis: "#Delta R_{t, #bar{t}}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_Top_Pt_CAT_base_ID??_Iso*':
+  x-axis: "P_{T, top 1}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_Top_Eta_CAT_base_ID??_Iso*':
+  x-axis: "#eta_{top 1}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_AntiTop_Pt_CAT_base_ID??_Iso*':
+  x-axis: "P_{T, top 2}"
+  y-axis: "Events"
+  y-axis-format: "%1% / %2$.1f"
+  normalized: false
+  log-y: both
+  save-extensions: ["png"]
+  show-ratio: true
+
+'llbbMet_RecoTop_AntiTop_Eta_CAT_base_ID??_Iso*':
   x-axis: "#eta_{top 2}"
   y-axis: "Events"
   y-axis-format: "%1% / %2$.1f"


### PR DESCRIPTION
This PR adds the TTbar system reconstruction with smearing, using external files compiled with histFactory.

A litte fiddling around is needed in `generatePlots.py`, to create the `TTAnalysis::TTBar` objects first (using the correct objects in each sub-category), and retrieve the right ones in the plots themselves.

Also, the lumi is corrected, and the correct lepton Iso/IDs are used (to be in sync with the HLT scale factors).
